### PR TITLE
Scrollbar for recent element creations

### DIFF
--- a/game/ts/element-game/recents.ts
+++ b/game/ts/element-game/recents.ts
@@ -35,15 +35,17 @@ export async function InitElementNews() {
     const newsItems = await Promise.all(combinations.map((x) => getRecentCombinationDOM(rc, x)));
 
     const container = document.querySelector('.news-container');
+    const sidebar = document.querySelector('#element-sidebar');
     container.innerHTML = '';
     newsItems.forEach(x => container.appendChild(x));
 
     async function onNewRecent() {
       rc.waitForNewRecent().then(onNewRecent);
       playSound('news.new-element');
+      sidebar.scrollTo(0,0);
       const combo = await rc.getRecentCombinations(1);
       const elem = await getRecentCombinationDOM(rc, combo[0]);
-      elem.classList.add('animate-in')
+      elem.classList.add('animate-in');
       container.prepend(elem);
     }
     rc.waitForNewRecent().then(onNewRecent);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,10 @@ const webpack = require('webpack');
 const gamedir = path.resolve(__dirname, 'game');
 const {execSync} = require('child_process');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
- 
+const date = new Date();
+const build_date = `${date.getFullYear()}-${date.getMonth().toString().padStart(2,'0')}-${date.getDate().toString().padStart(2,'0')} ${date.getHours()}:${date.getMinutes().toString().padStart(2,'0')}`
+
+console.log(JSON.stringify(build_date))
 let version = require('./package.json').version;
 if (process.env.CONTEXT === 'deploy-preview') version += '-' + (process.env.COMMIT_REF || 'unknown').slice(0, 4);
 if (process.env.CONTEXT === 'branch-deploy') version += '-dev-' + (process.env.COMMIT_REF || 'unknown').slice(0, 4);
@@ -26,7 +29,7 @@ module.exports = (prod = false) => ({
             $version: JSON.stringify(version),
             $isDevDeployBranch: (process.env.CONTEXT === 'deploy-preview') || (process.env.CONTEXT === 'branch-preview'),
             $production: JSON.stringify(prod),
-            $build_date: JSON.stringify(execSync('date +"%F %H:%M:%S"').toString()),
+            $build_date: JSON.stringify(build_date),
             $password: JSON.stringify(/*prod ? 'username' : */false)
         }),
         new webpack.IgnorePlugin(/polling-xhr\.js/),

--- a/workshop/themes/elem4_default/style.css
+++ b/workshop/themes/elem4_default/style.css
@@ -483,6 +483,7 @@ input[type='text'], input[type='password'], input[type='email'] {
   background-color: var(--background-main);
   color: var(--text-main);
   flex: 0 0 350px;
+  overflow-y: overlay;
 }
 #element-sidebar h2 {
   text-align: center;


### PR DESCRIPTION
This adds a scrollbar to the recent elements sidebar so that you can scroll down to see more elements. When a new element is created it will automatically go to the top.

This also changes the build_date implementation so it supports windows (ty for the fix @davecaruso 😄) 

Slight Warning: Im using `overflow-y: overlay` to show the scrollbar (so that it doesn't take up any space), which is apparently [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow) even though the newer alternative is [supported by **no** browsers.](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter)